### PR TITLE
Remove one password from spraying default passwords

### DIFF
--- a/atomics/T1110.003/T1110.003.yaml
+++ b/atomics/T1110.003/T1110.003.yaml
@@ -64,7 +64,7 @@ atomic_tests:
     passwords:
       description: list of passwords we will attempt to brute force with (not too many, else it's more a bruteforce than a password spraying)
       type: String
-      default: Pa`$`$w0rd`n123456`npassword
+      default: 123456`npassword
     dc:
       description: Name of the domain controller we will target (without domain FQDN suffix)
       type: String


### PR DESCRIPTION
Escaped dollar sign does not display well in webapp, and 2 attempts is largely enough for a password spraying anyway (!= bruteforce)